### PR TITLE
【Fixed】helperとassetsファイルが自動で生成されないように設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,9 @@ module Facebookapp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1 

`rails g`コマンドの際にhelperとassetsファイルが自動で生成されないように設定
